### PR TITLE
fixed rollback digging, added ownercheck

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -181,7 +181,11 @@ local function rollback_filling(player)
 		end
 	end
 	minetest.set_node(rollback_storage.pos, {name="air"})                  -- this more save in case of clay and other things which change shape if dug
-	inv:add_item("main", node.name)                                        -- in case of rollback, dug items should be returned
+	if inv:room_for_item("main", node.name) then
+		inv:add_item("main", node.name)                                        -- in case of rollback, dug items should be returned
+	else
+		minetest.item_drop(ItemStack(node.name), player, rollback_storage.pos)
+	end
 	local node_sounds = minetest.registered_nodes[node.name].sounds
 	if node_sounds and node_sounds.dug then
 		minetest.sound_play(minetest.registered_nodes[node.name].sounds.dug, {pos = rollback_storage.pos})


### PR DESCRIPTION
minetest.dig_node does not work in every situation. For example if you dig default:clay you will get clay lumps when using this.

ownercheck makes the tool only usuable by the player who first used it. This prevents griefing on multiplayer servers and should be used together with recipe_on = false to disable the crafting
of the filler tool.
(default is ownercheck off and recipes on like you made it)

The rollback command is not really short :) /rsq is maybe easier for typing noobs like me :D 


